### PR TITLE
Add video option tile component, implement basic home page, revise upload

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,1 @@
-API_URL="http://localhost:3000"
+VITE_API_URL="http://localhost:3000"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,7 @@ function App() {
     },
     palette: {
       primary: {
-        main: "#FFFFFF",
+        main: "#78C5DC",
       },
       secondary: {
         main: "#F5F5F5",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import {
   BrowserRouter as Router,
   Routes,
 } from "react-router-dom";
+import Home from "./components/Home";
 import Layout from "./components/Layout";
 import Login from "./components/Login";
 import Profile from "./components/Profile";
@@ -32,7 +33,14 @@ function App() {
         <Router>
           <Routes>
             <Route path="/login" element={<Login />} />
-            <Route path="/home" element={<Layout />} />
+            <Route
+              path="/home"
+              element={
+                <Layout>
+                  <Home />
+                </Layout>
+              }
+            />
             <Route
               path="/profile"
               element={

--- a/src/components/Home/index.tsx
+++ b/src/components/Home/index.tsx
@@ -1,11 +1,43 @@
+import { Grid2 as Grid } from "@mui/material";
+import { useEffect, useState } from "react";
+import { useUser } from "../../hooks/useUser";
+import { getVideoOptions } from "../../utils/api";
+import { VideoOption } from "../../utils/types";
+import VideoOptionTile from "../VideoOptionTile";
+
+// TODO: Make order "random", paginate while scrolling
+// TODO: Make skeleton while loading?
+
 /**
  * Front page component.
- * Shows random list of videos, showing more as user scrolls.
+ * Shows list of videos.
  */
 function Home() {
-  // TODO: Create homepage.
+  const { user } = useUser();
+  const [videoList, setVideoList] = useState<VideoOption[]>([]);
 
-  return ();
+  useEffect(() => {
+    const fetchVideoOptions = async () => {
+      if (!user) return;
+      const token = await user?.getIdToken();
+      const newVideoList = await getVideoOptions(token);
+      if (newVideoList.length > 0) {
+        setVideoList(newVideoList);
+      }
+    };
+
+    fetchVideoOptions();
+  }, [user]);
+
+  return (
+    <Grid container spacing={3}>
+      {videoList.map((video) => (
+        <Grid size={{ xs: 7, sm: 6, md: 4, lg: 4 }} key={video.id}>
+          <VideoOptionTile video={video} />
+        </Grid>
+      ))}
+    </Grid>
+  );
 }
 
 export default Home;

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -181,7 +181,9 @@ function Layout({ children }: LayoutProps) {
           )}
         </Toolbar>
       </AppBar>
-      <Box color="secondary">{children && children}</Box>
+      <Container color="secondary" sx={styles.mainContent}>
+        {children && children}
+      </Container>
     </Container>
   );
 }

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -94,12 +94,8 @@ function Layout({ children }: LayoutProps) {
 
   return (
     <Container maxWidth={false} disableGutters>
-      <AppBar position="sticky" sx={styles.appBar}>
-        <Toolbar
-          sx={{
-            alignItems: "center",
-          }}
-        >
+      <AppBar position="sticky" sx={styles.appBar} color="default">
+        <Toolbar sx={styles.toolbar}>
           <Box
             sx={{
               ...styles.leftContainer,
@@ -185,7 +181,7 @@ function Layout({ children }: LayoutProps) {
           )}
         </Toolbar>
       </AppBar>
-      {children && children}
+      <Box color="secondary">{children && children}</Box>
     </Container>
   );
 }

--- a/src/components/Layout/styles.ts
+++ b/src/components/Layout/styles.ts
@@ -59,6 +59,11 @@ const styles = {
     overflow: "visible",
     filter: "drop-shadow(0px 2px 8px rgba(0,0,0,0.32))",
   },
+  mainContent: {
+    width: "100%",
+    paddingTop: "24px",
+    margin: 0,
+  },
 };
 
 export default styles;

--- a/src/components/Layout/styles.ts
+++ b/src/components/Layout/styles.ts
@@ -1,6 +1,10 @@
 const styles = {
   appBar: {
     width: "100%",
+    backgroundColor: "#FFFFFF",
+  },
+  toolbar: {
+    alignItems: "center",
   },
   leftContainer: {
     display: "flex",

--- a/src/components/Profile/UploadForm.tsx
+++ b/src/components/Profile/UploadForm.tsx
@@ -21,6 +21,7 @@ import { useUser } from "../../hooks/useUser";
 import { uploadVideo } from "../../utils/api";
 
 function UploadForm() {
+  const { user } = useUser();
   const [dialogOpen, setDialogOpen] = useState<boolean>(true);
   const [title, setTitle] = useState<string>("");
   const [description, setDescription] = useState<string>("");
@@ -29,8 +30,6 @@ function UploadForm() {
   const [thumbnailError, setThumbnailError] = useState<string | null>(null);
   const [videoPreview, setVideoPreview] = useState<string | null>(null);
   const [thumbnailPreview, setThumbnailPreview] = useState<string | null>(null);
-
-  const { user } = useUser();
 
   /**
    * Handle attaching a video file.
@@ -116,8 +115,6 @@ function UploadForm() {
     const token = await user?.getIdToken();
     uploadVideo(title, description, videoFile, thumbnailFile, user?.uid, token);
   }
-
-  function handleClose() {}
 
   return (
     <Dialog
@@ -258,9 +255,7 @@ function UploadForm() {
           )}
         </Box>
         <DialogActions>
-          <Button variant="outlined" onClick={handleClose}>
-            Cancel
-          </Button>
+          <Button variant="outlined">Cancel</Button>
           <Button
             type="submit"
             variant="contained"

--- a/src/components/VideoOption/index.tsx
+++ b/src/components/VideoOption/index.tsx
@@ -1,9 +1,0 @@
-/**
- * Video option on home page and video sidebar.
- * Shows a video thumbnail, title, author, views, and upload date.
- */
-function VideoOption() {
-  // TODO: Create video option for home page
-}
-
-export default VideoOption;

--- a/src/components/VideoOptionTile/index.tsx
+++ b/src/components/VideoOptionTile/index.tsx
@@ -6,6 +6,8 @@ type VideoOptionTileProps = {
   video: VideoOption;
 };
 
+// TODO: Link to videos on title and thumbnail
+
 /**
  * Video option on home page and video sidebar.
  * Shows a video thumbnail, title, author, views, and time since upload.

--- a/src/components/VideoOptionTile/index.tsx
+++ b/src/components/VideoOptionTile/index.tsx
@@ -1,0 +1,70 @@
+import { Avatar, Box, Stack, Typography } from "@mui/material";
+import { styles } from "./styles";
+import { VideoOption } from "../../utils/types";
+
+type VideoOptionTileProps = {
+  video: VideoOption;
+};
+
+/**
+ * Video option on home page and video sidebar.
+ * Shows a video thumbnail, title, author, views, and time since upload.
+ */
+function VideoOptionTile({ video }: VideoOptionTileProps) {
+  /**
+   * Find the time since upload, rounded to the largest unit of time.
+   * @param {string} uploadDate Upload time in UTC format.
+   * @returns {string} String showing time since upload.
+   */
+  function timeSinceUpload(uploadDate: string): string {
+    const uploadTime = new Date(uploadDate);
+    const now = new Date();
+    const diffInSeconds = Math.floor(
+      (now.getTime() - uploadTime.getTime()) / 1000
+    );
+
+    if (diffInSeconds < 60) return `${diffInSeconds} seconds ago`;
+    const diffInMinutes = Math.floor(diffInSeconds / 60);
+    if (diffInMinutes < 60) return `${diffInMinutes} minutes ago`;
+    const diffInHours = Math.floor(diffInMinutes / 60);
+    if (diffInHours < 24) return `${diffInHours} hours ago`;
+    const diffInDays = Math.floor(diffInHours / 24);
+    if (diffInDays < 30) return `${diffInDays} days ago`;
+    const diffInMonths = Math.floor(diffInDays / 30);
+    if (diffInMonths < 12) return `${diffInMonths} months ago`;
+    const diffInYears = Math.floor(diffInMonths / 12);
+    return `${diffInYears} years ago`;
+  }
+
+  return (
+    <Box sx={styles.tile}>
+      <Box sx={styles.thumbnailContainer}>
+        <Box
+          component="img"
+          src={video.thumbnailSignedLink}
+          alt={`${video.title} thumbnail`}
+          sx={styles.thumbnail}
+        />
+      </Box>
+      <Stack direction="row" alignItems="center" spacing={2}>
+        <Avatar
+          src={video.uploaderPfp}
+          alt={`${video.uploaderDisplayName}'s profile picture`}
+        />
+        <Box>
+          <Typography variant="body1" noWrap>
+            {video.title}
+          </Typography>
+          <Typography variant="body2" color="textSecondary" noWrap>
+            {video.uploaderDisplayName}{" "}
+          </Typography>
+          <Typography variant="body2" color="textSecondary" noWrap>
+            {video.views} views • {timeSinceUpload(video.uploadDate)}{" "}
+          </Typography>
+        </Box>
+      </Stack>
+    </Box>
+  );
+}
+
+export default VideoOptionTile;

--- a/src/components/VideoOptionTile/styles.ts
+++ b/src/components/VideoOptionTile/styles.ts
@@ -1,0 +1,24 @@
+export const styles = {
+  tile: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 1,
+  },
+  thumbnailContainer: {
+    position: "relative",
+    width: "100%",
+    paddingTop: "56.25%",
+    backgroundColor: "gray",
+    overflow: "hidden",
+    borderRadius: 3,
+  },
+  thumbnail: {
+    position: "absolute",
+    top: "50%",
+    left: "50%",
+    transform: "translate(-50%, -50%)",
+    width: "100%",
+    height: "100%",
+    objectFit: "cover",
+  },
+};

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,3 +1,16 @@
+import { VideoOption } from "./types";
+
+const apiUrl = import.meta.env.VITE_API_URL;
+
+/**
+ * Upload a video and thumbnail (optional) to the API.
+ * @param {string} title Title of the video.
+ * @param {string} description Description of the video.
+ * @param {File | null} videoFile The video file to upload.
+ * @param {File | null} thumbnailFile The thumbnail file to upload (optional).
+ * @param {string} uploader The uploader's UID.
+ * @param {string} token JWT for authorization.
+ */
 export function uploadVideo(
   title: string,
   description: string,
@@ -13,7 +26,6 @@ export function uploadVideo(
   if (videoFile) formData.append("videoFile", videoFile);
   if (thumbnailFile) formData.append("thumbnailFile", thumbnailFile);
 
-  const apiUrl = import.meta.env.VITE_API_URL;
   fetch(`${apiUrl}/video`, {
     method: "POST",
     headers: {
@@ -28,4 +40,28 @@ export function uploadVideo(
     .catch((error) => {
       console.error("Error uploading video:", error);
     });
+}
+
+/**
+ * Fetch video options from the API.
+ * @param {string} token JWT for authorization.
+ * @returns {Promise<VideoOption[]>} Array of video options.
+ */
+export async function getVideoOptions(token?: string): Promise<VideoOption[]> {
+  try {
+    const response = await fetch(`${apiUrl}/video`, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    const data = await response.json();
+    if (!response.ok) {
+      throw new Error(data.error);
+    }
+    return data.videoOptions;
+  } catch (error) {
+    console.error("Error fetching video options:", error);
+    return [];
+  }
 }

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,19 +1,19 @@
 export function uploadVideo(
   title: string,
   description: string,
-  uploader: string,
   videoFile: File | null,
   thumbnailFile: File | null,
+  uploader?: string,
   token?: string
 ) {
   const formData = new FormData();
   formData.append("title", title);
   formData.append("description", description);
-  formData.append("uploaderUsername", uploader);
+  if (uploader) formData.append("uploader", uploader);
   if (videoFile) formData.append("videoFile", videoFile);
   if (thumbnailFile) formData.append("thumbnailFile", thumbnailFile);
 
-  const apiUrl = process.env.API_URL;
+  const apiUrl = import.meta.env.VITE_API_URL;
   fetch(`${apiUrl}/video`, {
     method: "POST",
     headers: {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,10 @@
+// Representation of a video that a user can select to watch.
+export type VideoOption = {
+  id: string;
+  title: string;
+  uploaderDisplayName: string;
+  uploaderPfp: string;
+  uploadDate: string;
+  views: number;
+  thumbnailSignedLink: string;
+};


### PR DESCRIPTION
These changes add a rudimentary home page that shows all available videos. These videos are shown using the new VideoOptionTile component, which displays a single video's thumbnail, title, uploading user, viewcount, and the time since its upload. This homepage should be expanded later to implement a skeleton while loading and server-side pagination on scroll.

Additionally, the upload form has been tweaked to look better and function as is expected by the backend.